### PR TITLE
EXO-58026 : fix loading distribution type object

### DIFF
--- a/src/main/groovy/org/exoplatform/platform/am/AddonService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/AddonService.groovy
@@ -555,6 +555,8 @@ class AddonService {
     addonObj.supported = anAddon.supported
     if (anAddon.supportedDistributions instanceof String) {
       addonObj.supportedDistributions = Arrays.asList(anAddon.supportedDistributions.split(','))
+    } else {
+      addonObj.supportedDistributions = anAddon.supportedDistributions
     }
     if (anAddon.supportedApplicationServers instanceof String) {
       addonObj.supportedApplicationServers = anAddon.supportedApplicationServers.split(',').collect {


### PR DESCRIPTION
When loading the property supportedDistributions from a Json file, they are already converted in a List object, thus they are ignored when checked against String object.