### PR TITLE
fix: Delete Jcabi Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,20 +182,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </resources>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>weave-classes</id>
-            <phase />
-          </execution>
-          <execution>
-            <id>weave-test-classes</id>
-            <phase />
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <executions>


### PR DESCRIPTION
This change will delete JCabi Plugin usage in favor of AspectJ Plugin for AspectJ Annotation processing.