### PR TITLE
feat: Add support for JSON-based credentials file for multiple server authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,49 @@ set ADDONSMGR_PROPERTIES=-Daddonsmgr.auth.type=bearer -Daddonsmgr.auth.token=eyJ
 addon.bat list
 ```
 
+#### JSON-based Credentials File
+
+For more complex scenarios, such as multiple servers with different credentials, you can use a JSON-based credentials file. This file supports URL regex matching and environment variable interpolation.
+
+To use a credentials file, set the following system property:
+
+- ```addonsmgr.auth.credentials.file=<path-to-json-file>```
+
+**Example JSON file:**
+```json
+[
+  {
+    "url": "https://repository.exoplatform.org/.*",
+    "type": "basic",
+    "username": "user1",
+    "password": "${USER1_PASSWORD}"
+  },
+  {
+    "url": "https://other.server.com/api/.*",
+    "type": "bearer",
+    "token": "${OTHER_TOKEN}"
+  }
+]
+```
+
+**Linux/Mac (bash):**
+```bash
+export ADDONSMGR_PROPERTIES="-Daddonsmgr.auth.credentials.file=/path/to/credentials.json"
+./addon list
+```
+
+**Windows (Command Prompt):**
+```bash
+set ADDONSMGR_PROPERTIES=-Daddonsmgr.auth.credentials.file=C:\\path\\to\\credentials.json
+addon.bat list
+```
+
+**Notes on JSON format:**
+- The file can be a JSON array or a JSON object with a `credentials` property containing the array.
+- `url`: A string or a regex pattern to match the download URL.
+- `type`: `basic` or `bearer`.
+- `${VAR_NAME}`: Will be replaced by the value of the environment variable `VAR_NAME`.
+
 #### Multiple Properties
 
 You can combine multiple system properties in the ```ADDONSMGR_PROPERTIES``` variable:

--- a/src/main/groovy/org/exoplatform/platform/am/utils/CredentialsService.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/utils/CredentialsService.groovy
@@ -1,0 +1,132 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.platform.am.utils
+
+import groovy.json.JsonSlurper
+import org.exoplatform.platform.am.ex.InvalidJSONException
+
+import java.util.regex.Pattern
+
+/**
+ * Service to manage credentials from a JSON file
+ */
+class CredentialsService {
+
+  private static final Logger LOG = Logger.getInstance()
+
+  private List<Map> credentials = []
+
+  /**
+   * Environment variables map (for interpolation)
+   */
+  Map env = System.getenv()
+
+  CredentialsService() {
+    reload()
+  }
+
+  /**
+   * Reload credentials from the file specified in system property "addonsmgr.auth.credentials.file"
+   */
+  void reload() {
+    String credentialsFilePath = System.getProperty("addonsmgr.auth.credentials.file")
+    if (credentialsFilePath) {
+      loadCredentials(credentialsFilePath)
+    } else {
+      credentials = []
+    }
+  }
+
+  /**
+   * Load credentials from a JSON file
+   * @param filePath The path to the JSON file
+   */
+  void loadCredentials(String filePath) {
+    File file = new File(filePath)
+    if (!file.exists()) {
+      LOG.warn("Credentials file not found: ${filePath}")
+      return
+    }
+
+    try {
+      def json = new JsonSlurper().parse(file)
+      if (json instanceof Map && json.credentials instanceof List) {
+        credentials = json.credentials
+      } else if (json instanceof List) {
+        credentials = json
+      } else {
+        throw new InvalidJSONException("Invalid credentials format in ${filePath}. Expected a list or an object with a 'credentials' list.")
+      }
+      LOG.debug("Loaded ${credentials.size()} credentials from ${filePath}")
+    } catch (Exception e) {
+      LOG.error("Error loading credentials from ${filePath}: ${e.message}")
+    }
+  }
+
+  /**
+   * Get credentials for a given URL
+   * @param url The URL to match
+   * @return The matching credentials or null if not found
+   */
+  Map getCredentialsForURL(String url) {
+    for (Map entry in credentials) {
+      String pattern = entry.url
+      if (pattern && (url == pattern || url.matches(pattern))) {
+        return interpolateCredentials(entry)
+      }
+    }
+    return null
+  }
+
+  /**
+   * Interpolate environment variables in credentials
+   * @param entry The credentials entry
+   * @return The interpolated credentials
+   */
+  private Map interpolateCredentials(Map entry) {
+    Map result = [:]
+    entry.each { k, v ->
+      if (v instanceof String) {
+        result[k] = interpolate(v)
+      } else if (v instanceof Map) {
+        result[k] = interpolateCredentials(v)
+      } else {
+        result[k] = v
+      }
+    }
+    return result
+  }
+
+  /**
+   * Interpolate environment variables in a string
+   * @param value The string to interpolate
+   * @return The interpolated string
+   */
+  private String interpolate(String value) {
+    if (!value) return value
+    
+    // Match ${VAR_NAME}
+    return value.replaceAll(/\$\{(.+?)\}/) { match, varName ->
+      String envValue = env[varName]
+      if (envValue != null) {
+        return envValue
+      }
+      LOG.warn("Environment variable ${varName} not found for interpolation")
+      return match
+    }
+  }
+}

--- a/src/main/groovy/org/exoplatform/platform/am/utils/FileUtils.groovy
+++ b/src/main/groovy/org/exoplatform/platform/am/utils/FileUtils.groovy
@@ -31,6 +31,11 @@ class FileUtils {
    * Logger
    */
   private static final Logger LOG = Logger.getInstance()
+
+  /**
+   * Credentials service
+   */
+  static final CredentialsService CREDENTIALS_SERVICE = new CredentialsService()
   
   /**
    * System property prefix for authentication
@@ -79,6 +84,16 @@ class FileUtils {
     if (!(conn instanceof HttpURLConnection)) {
       return
     }
+
+    HttpURLConnection httpConn = (HttpURLConnection) conn
+    String url = httpConn.getURL().toString()
+
+    // Try to get credentials from service first
+    Map credentials = CREDENTIALS_SERVICE.getCredentialsForURL(url)
+    if (credentials) {
+      applyCredentials(httpConn, credentials)
+      return
+    }
     
     String authType = getAuthType()
     if (!authType) {
@@ -86,12 +101,30 @@ class FileUtils {
       return
     }
     
-    HttpURLConnection httpConn = (HttpURLConnection) conn
-    
+    Map legacyCredentials = [
+      type: authType,
+      username: getAuthUsername(),
+      password: getAuthPassword(),
+      token: getAuthToken()
+    ]
+    applyCredentials(httpConn, legacyCredentials)
+  }
+
+  /**
+   * Apply credentials to a HTTP URL connection
+   * @param httpConn The HTTP URL connection
+   * @param credentials The credentials to apply
+   */
+  private static void applyCredentials(HttpURLConnection httpConn, Map credentials) {
+    String authType = credentials.type
+    if (!authType) {
+      return
+    }
+
     switch (authType.toLowerCase()) {
       case AUTH_TYPE_BASIC:
-        String username = getAuthUsername()
-        String password = getAuthPassword()
+        String username = credentials.username
+        String password = credentials.password
         
         if (username && password) {
           String auth = "${username}:${password}"
@@ -99,18 +132,18 @@ class FileUtils {
           httpConn.setRequestProperty("Authorization", "Basic ${encodedAuth}")
           LOG.debug("Applied Basic authentication for user: ${username}")
         } else if (username || password) {
-          LOG.warn("Basic authentication configured but username or password missing. Please set -D${AUTH_PREFIX}username and -D${AUTH_PREFIX}password")
+          LOG.warn("Basic authentication configured but username or password missing. Please set -D${AUTH_PREFIX}username and -D${AUTH_PREFIX}password or check your credentials file.")
         }
         break
         
       case AUTH_TYPE_BEARER:
-        String token = getAuthToken()
+        String token = credentials.token
         
         if (token) {
           httpConn.setRequestProperty("Authorization", "Bearer ${token}")
           LOG.debug("Applied Bearer token authentication")
         } else {
-          LOG.warn("Bearer authentication configured but token missing. Please set -D${AUTH_PREFIX}token")
+          LOG.warn("Bearer authentication configured but token missing. Please set -D${AUTH_PREFIX}token or check your credentials file.")
         }
         break
         

--- a/src/test/groovy/org/exoplatform/platform/am/utils/CredentialsServiceTest.groovy
+++ b/src/test/groovy/org/exoplatform/platform/am/utils/CredentialsServiceTest.groovy
@@ -1,0 +1,140 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.platform.am.utils
+
+import org.exoplatform.platform.am.UnitTestsSpecification
+
+class CredentialsServiceTest extends UnitTestsSpecification {
+
+  def "test load credentials from JSON file (object format)"() {
+    given:
+    File tempFile = File.createTempFile("credentials", ".json")
+    tempFile.text = '''
+    {
+      "credentials": [
+        {
+          "url": "https://server1.com/.*",
+          "type": "basic",
+          "username": "user1",
+          "password": "pass1"
+        },
+        {
+          "url": "https://server2.com/.*",
+          "type": "bearer",
+          "token": "${TOKEN_VAR}"
+        }
+      ]
+    }
+    '''
+    CredentialsService service = new CredentialsService()
+    service.env = [TOKEN_VAR: "secret-token"]
+
+    when:
+    service.loadCredentials(tempFile.absolutePath)
+
+    then:
+    Map cred1 = service.getCredentialsForURL("https://server1.com/api")
+    cred1.type == "basic"
+    cred1.username == "user1"
+    cred1.password == "pass1"
+
+    Map cred2 = service.getCredentialsForURL("https://server2.com/download")
+    cred2.type == "bearer"
+    cred2.token == "secret-token"
+
+    cleanup:
+    tempFile.delete()
+  }
+
+  def "test load credentials from JSON file (list format)"() {
+    given:
+    File tempFile = File.createTempFile("credentials", ".json")
+    tempFile.text = '''
+    [
+      {
+        "url": "https://server1.com/.*",
+        "type": "basic",
+        "username": "user1",
+        "password": "pass1"
+      }
+    ]
+    '''
+    CredentialsService service = new CredentialsService()
+
+    when:
+    service.loadCredentials(tempFile.absolutePath)
+
+    then:
+    Map cred1 = service.getCredentialsForURL("https://server1.com/api")
+    cred1.type == "basic"
+    cred1.username == "user1"
+    cred1.password == "pass1"
+
+    cleanup:
+    tempFile.delete()
+  }
+
+  def "test regex matching"() {
+    given:
+    File tempFile = File.createTempFile("credentials", ".json")
+    tempFile.text = '''
+    [
+      {
+        "url": "https://.*\\\\.exoplatform\\\\.org/.*",
+        "type": "basic",
+        "username": "exo",
+        "password": "exo"
+      }
+    ]
+    '''
+    CredentialsService service = new CredentialsService()
+    service.loadCredentials(tempFile.absolutePath)
+
+    expect:
+    service.getCredentialsForURL("https://repository.exoplatform.org/public")?.username == "exo"
+    service.getCredentialsForURL("https://meeds.io") == null
+
+    cleanup:
+    tempFile.delete()
+  }
+  
+  def "test interpolation with missing env var"() {
+    given:
+    File tempFile = File.createTempFile("credentials", ".json")
+    tempFile.text = '''
+    [
+      {
+        "url": "https://server.com",
+        "type": "bearer",
+        "token": "${MISSING}"
+      }
+    ]
+    '''
+    CredentialsService service = new CredentialsService()
+    service.env = [:]
+    service.loadCredentials(tempFile.absolutePath)
+
+    when:
+    Map cred = service.getCredentialsForURL("https://server.com")
+
+    then:
+    cred.token == '${MISSING}'
+
+    cleanup:
+    tempFile.delete()
+  }
+}

--- a/src/test/groovy/org/exoplatform/platform/am/utils/FileUtilsIT.groovy
+++ b/src/test/groovy/org/exoplatform/platform/am/utils/FileUtilsIT.groovy
@@ -257,20 +257,92 @@ class FileUtilsIT extends IntegrationTestsSpecification {
     setup:
     def originalFile = new File(getTestDataDir(), "catalog.json")
     def downloadedFile = File.createTempFile("test", ".json")
-    
+
     // Set authentication properties
     System.setProperty("addonsmgr.auth.type", "basic")
     System.setProperty("addonsmgr.auth.username", "testuser")
     System.setProperty("addonsmgr.auth.password", "testpass")
-    
+
     when:
     // This should work even with auth properties set because it's a local file
     FileUtils.copyFile("Testing copy without auth", originalFile, downloadedFile)
-    
+
     then:
     originalFile.text.equals(downloadedFile.text)
-    
+
     cleanup:
     downloadedFile.delete()
   }
-}
+
+  def "[AM_AUTH_10] Download with credentials from JSON file should work"() {
+    setup:
+    def originalFile = new File(getTestDataDir(), "catalog.json")
+    def downloadedFile = File.createTempFile("test", ".json")
+
+    // Create credentials file
+    File credFile = File.createTempFile("credentials", ".json")
+    credFile.text = """
+    [
+      {
+        "url": "${getWebServerRootUrl()}/protected-catalog.json",
+        "type": "basic",
+        "username": "testuser",
+        "password": "testpass"
+      }
+    ]
+    """
+    System.setProperty("addonsmgr.auth.credentials.file", credFile.absolutePath)
+    FileUtils.CREDENTIALS_SERVICE.reload()
+
+    when:
+    FileUtils.downloadFile("Testing download with JSON credentials", 
+                          "${getWebServerRootUrl()}/protected-catalog.json", 
+                          downloadedFile)
+
+    then:
+    originalFile.text.equals(downloadedFile.text)
+
+    cleanup:
+    downloadedFile.delete()
+    credFile.delete()
+    System.clearProperty("addonsmgr.auth.credentials.file")
+    FileUtils.CREDENTIALS_SERVICE.reload()
+  }
+
+  def "[AM_AUTH_11] Download with credentials from JSON file and env var interpolation should work"() {
+    setup:
+    def originalFile = new File(getTestDataDir(), "catalog.json")
+    def downloadedFile = File.createTempFile("test", ".json")
+
+    // Create credentials file
+    File credFile = File.createTempFile("credentials", ".json")
+    credFile.text = """
+    [
+      {
+        "url": "${getWebServerRootUrl()}/protected-catalog.json",
+        "type": "basic",
+        "username": "testuser",
+        "password": "\${TEST_PASS_VAR}"
+      }
+    ]
+    """
+    System.setProperty("addonsmgr.auth.credentials.file", credFile.absolutePath)
+    FileUtils.CREDENTIALS_SERVICE.env = [TEST_PASS_VAR: "testpass"]
+    FileUtils.CREDENTIALS_SERVICE.reload()
+
+    when:
+    FileUtils.downloadFile("Testing download with JSON credentials and interpolation", 
+                          "${getWebServerRootUrl()}/protected-catalog.json", 
+                          downloadedFile)
+
+    then:
+    originalFile.text.equals(downloadedFile.text)
+
+    cleanup:
+    downloadedFile.delete()
+    credFile.delete()
+    System.clearProperty("addonsmgr.auth.credentials.file")
+    FileUtils.CREDENTIALS_SERVICE.env = System.getenv()
+    FileUtils.CREDENTIALS_SERVICE.reload()
+  }
+  }


### PR DESCRIPTION
Introduce a new CredentialsService to manage authentication for multiple servers via a JSON file. This file supports URL regex matching and environment variable interpolation.

Changes:
- Implement CredentialsService to load and match credentials from a JSON file.
- Support interpolation in credentials file for passwords and tokens.
- Integrate CredentialsService into FileUtils for automatic authentication header application.
- Update README.md with documentation and examples for the new feature.
- Add unit and integration tests for JSON-based credentials and interpolation.